### PR TITLE
Fix: Remove ACL and enforce bucket ownership for objects

### DIFF
--- a/terraform/frontend-bucket.tf
+++ b/terraform/frontend-bucket.tf
@@ -13,6 +13,13 @@ resource "aws_s3_bucket_public_access_block" "frontend_bucket_access" {
   restrict_public_buckets = true
 }
 
+resource "aws_s3_bucket_ownership_controls" "frontend_bucket_ownership" {
+  bucket = aws_s3_bucket.frontend_bucket.id
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
 resource "aws_s3_bucket_policy" "frontend_bucket_policy" {
   bucket = aws_s3_bucket.frontend_bucket.id
 


### PR DESCRIPTION
Access Control Lists (ACLs) are not best-practice for S3 and should be removed. We use a bucket policy instead.
Also, the recommended and best-practice setting for a S3 bucket is to enforce bucket ownership. This means all objects uploaded to a bucket (from whatever account) are owned by the account owning the bucket. This configuration is explicitly set now. With this configuration enabled, ACLs are disabled automatically.