### PR TITLE
Fix frontend login

### DIFF
--- a/backend/src/config/cost.ts
+++ b/backend/src/config/cost.ts
@@ -16,7 +16,6 @@ export namespace CostCategory {
   }
 }
 
-// TODO Add Lambda function that returns basic config/rule values for frontend
 const skillThresholds = [50, 75, 99999];
 
 /**
@@ -36,6 +35,7 @@ const costMatrix: number[][] = [
   [2, 3, 4],
 ];
 
+// TODO add separate Lambda function that returns skill costs for a given skill value and cost category
 export function getIncreaseCost(skillValue: number, costCategory: CostCategory): number {
   const columnIndex = skillThresholds.findIndex((threshold) => skillValue < threshold);
   return costMatrix[costCategory][columnIndex];

--- a/backend/src/lambdas/increase-skill/index.ts
+++ b/backend/src/lambdas/increase-skill/index.ts
@@ -110,6 +110,10 @@ async function increaseSkill(event: APIGatewayProxyEvent): Promise<APIGatewayPro
     console.log("Successfully updated DynamoDB item");
 
     // TODO save event in history
+    /** TODO check latency for increase skill
+     *  If latency high: return cost for next skill point for given cost category
+     *  If latency low: let frontend call separate Lambda for cost for given skill value and cost category
+     */
     const response = {
       statusCode: 200,
       body: JSON.stringify({

--- a/frontend/build_on_change.sh
+++ b/frontend/build_on_change.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# TODO check if frontend is re-deployed when Cognito user pool has changed and therefore the env variables for the frontend have changed
+
 CACHED_CHECKSUM="checksum.txt"
 
 # Check the frontend directory for changes and rebuild the frontend if changes are detected

--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -17,6 +17,8 @@ resource "aws_cognito_user_pool" "pnp_user_pool" {
     }
   }
 
+  alias_attributes = ["email"]
+
   auto_verified_attributes = ["email"]
 
   //deletion_protection = "ACTIVE" // TODO activate protection after Cognito pool is properly set up
@@ -41,10 +43,6 @@ resource "aws_cognito_user_pool" "pnp_user_pool" {
   }
 
   username_attributes = ["email"] // Require email address for sign up
-
-  username_configuration {
-    case_sensitive = true
-  }
 
   verification_message_template {
     default_email_option  = "CONFIRM_WITH_LINK"

--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -1,8 +1,6 @@
 resource "aws_cognito_user_pool" "pnp_user_pool" {
   name = "pnp-app-user-pool"
 
-  auto_verified_attributes = ["email"]
-
   account_recovery_setting {
     recovery_mechanism {
       name     = "verified_email"
@@ -13,6 +11,10 @@ resource "aws_cognito_user_pool" "pnp_user_pool" {
   admin_create_user_config {
     allow_admin_create_user_only = true
   }
+
+  alias_attributes = [ "email" ]
+
+  auto_verified_attributes = ["email"]
 
   deletion_protection = "ACTIVE"
 

--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -30,6 +30,17 @@ resource "aws_cognito_user_pool" "pnp_user_pool" {
     temporary_password_validity_days = 1
   }
 
+  schema {
+    name                = "email"
+    attribute_data_type = "String"
+    mutable             = true
+    required            = true
+    string_attribute_constraints {
+      max_length = 254 // https://stackoverflow.com/a/574698
+      min_length = 3   // https://stackoverflow.com/a/1423203
+    }
+  }
+
   // Keep the original attribute value active when an updated value is pending
   user_attribute_update_settings {
     attributes_require_verification_before_update = ["email"]

--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -12,7 +12,7 @@ resource "aws_cognito_user_pool" "pnp_user_pool" {
     allow_admin_create_user_only = true
   }
 
-  alias_attributes = [ "email" ]
+  alias_attributes = ["email"] // Allows to login via this attribute
 
   auto_verified_attributes = ["email"]
 

--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -17,8 +17,6 @@ resource "aws_cognito_user_pool" "pnp_user_pool" {
     }
   }
 
-  alias_attributes = ["email"]
-
   auto_verified_attributes = ["email"]
 
   //deletion_protection = "ACTIVE" // TODO activate protection after Cognito pool is properly set up
@@ -47,6 +45,14 @@ resource "aws_cognito_user_pool" "pnp_user_pool" {
   user_attribute_update_settings {
     attributes_require_verification_before_update = ["email"]
   }
+
+  /**
+   * In our case "alias_attributes" can't be used as it allows to create users with the same email address.
+   * Only one user can have one specific email address as "verified". Setting the same email address for
+   * another user as "verified", will set the address to "Not verified" for the other user.
+   * Nevertheless, the email address is not unique across users and the described behavior is confusing.
+   */
+  username_attributes = ["email"]
 
   username_configuration {
     case_sensitive = true

--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -11,6 +11,7 @@ resource "aws_cognito_user_pool" "pnp_user_pool" {
   admin_create_user_config {
     allow_admin_create_user_only = true
     invite_message_template {
+      email_message = "Your username is '{username}' and temporary password is: {####}"
       email_subject = "Your temporary password for PnP-Application"
     }
   }

--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -64,11 +64,6 @@ resource "aws_cognito_user_pool" "pnp_user_pool" {
   username_configuration {
     case_sensitive = true
   }
-
-  verification_message_template {
-    default_email_option  = "CONFIRM_WITH_LINK"
-    email_subject_by_link = "Verify your email address"
-  }
 }
 
 # Cognito App Client (Frontend will use this to initiate login)

--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -10,6 +10,9 @@ resource "aws_cognito_user_pool" "pnp_user_pool" {
 
   admin_create_user_config {
     allow_admin_create_user_only = true
+    invite_message_template {
+      email_subject = "Your temporary password for PnP-Application"
+    }
   }
 
   alias_attributes = ["email"] // Allows to login via this attribute
@@ -32,8 +35,18 @@ resource "aws_cognito_user_pool" "pnp_user_pool" {
     enabled = true
   }
 
+  // Keep the original attribute value active when an updated value is pending
+  user_attribute_update_settings {
+    attributes_require_verification_before_update = [ "email" ]
+  }
+
   username_configuration {
     case_sensitive = true
+  }
+
+  verification_message_template {
+    default_email_option = "CONFIRM_WITH_LINK"
+    email_subject_by_link = "Verify your email address"
   }
 }
 

--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -42,7 +42,9 @@ resource "aws_cognito_user_pool" "pnp_user_pool" {
     attributes_require_verification_before_update = ["email"]
   }
 
-  username_attributes = ["email"] // Require email address for sign up
+  username_configuration {
+    case_sensitive = true
+  }
 
   verification_message_template {
     default_email_option  = "CONFIRM_WITH_LINK"

--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -16,7 +16,7 @@ resource "aws_cognito_user_pool" "pnp_user_pool" {
 
   auto_verified_attributes = ["email"]
 
-  deletion_protection = "ACTIVE"
+  //deletion_protection = "ACTIVE" // TODO activate protection after Cognito pool is properly set up
 
   password_policy {
     minimum_length                   = 16

--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -42,8 +42,6 @@ resource "aws_cognito_user_pool" "pnp_user_pool" {
     attributes_require_verification_before_update = ["email"]
   }
 
-  username_attributes = ["email"]
-
   username_configuration {
     case_sensitive = true
   }

--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -17,6 +17,8 @@ resource "aws_cognito_user_pool" "pnp_user_pool" {
     }
   }
 
+  alias_attributes = ["email"]
+
   auto_verified_attributes = ["email"]
 
   //deletion_protection = "ACTIVE" // TODO activate protection after Cognito pool is properly set up

--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -14,6 +14,8 @@ resource "aws_cognito_user_pool" "pnp_user_pool" {
     allow_admin_create_user_only = true
   }
 
+  deletion_protection = "ACTIVE"
+
   password_policy {
     minimum_length                   = 16
     require_lowercase                = true
@@ -26,6 +28,10 @@ resource "aws_cognito_user_pool" "pnp_user_pool" {
   mfa_configuration = "ON"
   software_token_mfa_configuration {
     enabled = true
+  }
+
+  username_configuration {
+    case_sensitive = true
   }
 }
 

--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -35,10 +35,6 @@ resource "aws_cognito_user_pool" "pnp_user_pool" {
     attribute_data_type = "String"
     mutable             = true
     required            = true
-    string_attribute_constraints {
-      max_length = 254 // https://stackoverflow.com/a/574698
-      min_length = 3   // https://stackoverflow.com/a/1423203
-    }
   }
 
   // Keep the original attribute value active when an updated value is pending

--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -37,7 +37,7 @@ resource "aws_cognito_user_pool" "pnp_user_pool" {
 
   // Keep the original attribute value active when an updated value is pending
   user_attribute_update_settings {
-    attributes_require_verification_before_update = [ "email" ]
+    attributes_require_verification_before_update = ["email"]
   }
 
   username_configuration {
@@ -45,7 +45,7 @@ resource "aws_cognito_user_pool" "pnp_user_pool" {
   }
 
   verification_message_template {
-    default_email_option = "CONFIRM_WITH_LINK"
+    default_email_option  = "CONFIRM_WITH_LINK"
     email_subject_by_link = "Verify your email address"
   }
 }

--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -13,6 +13,7 @@ resource "aws_cognito_user_pool" "pnp_user_pool" {
     invite_message_template {
       email_message = "Your username is '{username}' and temporary password is: {####}"
       email_subject = "Your temporary password for PnP-Application"
+      sms_message   = "Your username is '{username}' and temporary password is: {####}"
     }
   }
 

--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -30,6 +30,7 @@ resource "aws_cognito_user_pool" "pnp_user_pool" {
     temporary_password_validity_days = 1
   }
 
+  // Require the attribute "email" during sign-up. Normally, it is only optional.
   schema {
     name                = "email"
     attribute_data_type = "String"
@@ -51,6 +52,12 @@ resource "aws_cognito_user_pool" "pnp_user_pool" {
    * Only one user can have one specific email address as "verified". Setting the same email address for
    * another user as "verified", will set the address to "Not verified" for the other user.
    * Nevertheless, the email address is not unique across users and the described behavior is confusing.
+   *
+   * "username_attributes" forces the user to set an email address when signing up.
+   * The email address is unique across users, i.e. there can't be two users with the same email address.
+   * For sign-in the user must provide its email address.
+   * Notice: Even if the email is handled as username in the sign-up context, the actual username is set to
+   * an unique id (the same as the attribute 'sub') and the email is stored as "email" attribute.
    */
   username_attributes = ["email"]
 

--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -17,8 +17,6 @@ resource "aws_cognito_user_pool" "pnp_user_pool" {
     }
   }
 
-  alias_attributes = ["email"]
-
   auto_verified_attributes = ["email"]
 
   //deletion_protection = "ACTIVE" // TODO activate protection after Cognito pool is properly set up
@@ -36,6 +34,8 @@ resource "aws_cognito_user_pool" "pnp_user_pool" {
   user_attribute_update_settings {
     attributes_require_verification_before_update = ["email"]
   }
+
+  username_attributes = ["email"]
 
   username_configuration {
     case_sensitive = true

--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -35,6 +35,10 @@ resource "aws_cognito_user_pool" "pnp_user_pool" {
     attribute_data_type = "String"
     mutable             = true
     required            = true
+    string_attribute_constraints {
+      max_length = 254 // https://stackoverflow.com/a/574698
+      min_length = 3   // https://stackoverflow.com/a/1423203
+    }
   }
 
   // Keep the original attribute value active when an updated value is pending

--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -32,11 +32,6 @@ resource "aws_cognito_user_pool" "pnp_user_pool" {
     temporary_password_validity_days = 1
   }
 
-  mfa_configuration = "ON"
-  software_token_mfa_configuration {
-    enabled = true
-  }
-
   // Keep the original attribute value active when an updated value is pending
   user_attribute_update_settings {
     attributes_require_verification_before_update = ["email"]

--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -15,8 +15,6 @@ resource "aws_cognito_user_pool" "pnp_user_pool" {
     }
   }
 
-  alias_attributes = ["email"] // Allows to login via this attribute
-
   auto_verified_attributes = ["email"]
 
   //deletion_protection = "ACTIVE" // TODO activate protection after Cognito pool is properly set up
@@ -39,6 +37,8 @@ resource "aws_cognito_user_pool" "pnp_user_pool" {
   user_attribute_update_settings {
     attributes_require_verification_before_update = ["email"]
   }
+
+  username_attributes = ["email"] // Require email address for sign up
 
   username_configuration {
     case_sensitive = true

--- a/terraform/cognito.tf
+++ b/terraform/cognito.tf
@@ -2,11 +2,12 @@ resource "aws_cognito_user_pool" "pnp_user_pool" {
   name = "pnp-app-user-pool"
 
   auto_verified_attributes = ["email"]
-  schema {
-    attribute_data_type = "String"
-    name                = "email"
-    required            = true
-    mutable             = true
+
+  account_recovery_setting {
+    recovery_mechanism {
+      name     = "verified_email"
+      priority = 1
+    }
   }
 
   admin_create_user_config {


### PR DESCRIPTION
- Set up Cognito user pool in a way corresponding to our use case:
  - Use an email address to sign up and sign in
  - Allow password recovery via email
  - Add template for invitation mail
  - Disable MFA
  - Keep original attribute value active when an update is pending (e.g. for the email address)
  - Make username case sensitive
- Update script to create a Cognito user:
  - Send all output and error messages directly to the console (suppress AWS pager)
  - Set mail address as verified
  - Suppress invitation mail as temporary password will be directly overwritten
- Add TODOs