### PR TITLE
Update attribute endpoint: Change all values instead of only current value

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,9 +14,9 @@
         "get-characters": "file:src/lambdas/get-characters",
         "get-history": "file:src/lambdas/get-history",
         "get-skill-increase-cost": "file:src/lambdas/get-skill-increase-cost",
-        "increase-attribute": "file:src/lambdas/increase-attribute",
         "revert-history-record": "file:src/lambdas/revert-history-record",
         "set-history-comment": "file:src/lambdas/set-history-comment",
+        "update-attribute": "file:src/lambdas/update-attribute",
         "update-combat-values": "file:src/lambdas/update-combat-values",
         "update-skill": "file:src/lambdas/update-skill",
         "utils": "file:src/utils"
@@ -4613,10 +4613,6 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/increase-attribute": {
-      "resolved": "src/lambdas/increase-attribute",
-      "link": true
-    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -6679,6 +6675,10 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/update-attribute": {
+      "resolved": "src/lambdas/update-attribute",
+      "link": true
+    },
     "node_modules/update-combat-values": {
       "resolved": "src/lambdas/update-combat-values",
       "link": true
@@ -7181,18 +7181,18 @@
         "@types/node": "^22.9.0"
       }
     },
-    "src/lambdas/increase-attribute": {
-      "version": "1.0.0",
-      "devDependencies": {
-        "@types/aws-lambda": "^8.10.145",
-        "@types/node": "^22.9.0"
-      }
-    },
     "src/lambdas/revert-history-record": {
       "version": "1.0.0"
     },
     "src/lambdas/set-history-comment": {
       "version": "1.0.0"
+    },
+    "src/lambdas/update-attribute": {
+      "version": "1.0.0",
+      "devDependencies": {
+        "@types/aws-lambda": "^8.10.145",
+        "@types/node": "^22.9.0"
+      }
     },
     "src/lambdas/update-combat-values": {
       "version": "1.0.0"

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,9 +18,9 @@
     "get-characters": "file:src/lambdas/get-characters",
     "get-history": "file:src/lambdas/get-history",
     "get-skill-increase-cost": "file:src/lambdas/get-skill-increase-cost",
-    "increase-attribute": "file:src/lambdas/increase-attribute",
     "revert-history-record": "file:src/lambdas/revert-history-record",
     "set-history-comment": "file:src/lambdas/set-history-comment",
+    "update-attribute": "file:src/lambdas/update-attribute",
     "update-combat-values": "file:src/lambdas/update-combat-values",
     "update-skill": "file:src/lambdas/update-skill",
     "utils": "file:src/utils"

--- a/backend/src/lambdas/increase-attribute/index.ts
+++ b/backend/src/lambdas/increase-attribute/index.ts
@@ -1,5 +1,6 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import { getAttribute, Attribute } from "config/index.js";
+import { z } from "zod";
+import { getAttribute, Attribute, CalculationPoints } from "config/index.js";
 import {
   Request,
   parseBody,
@@ -12,7 +13,7 @@ import {
 } from "utils/index.js";
 
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
-  return increaseAttribute({
+  return _updateAttribute({
     headers: event.headers,
     pathParameters: event.pathParameters,
     queryStringParameters: event.queryStringParameters,
@@ -20,83 +21,71 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
   });
 };
 
+const bodySchema = z
+  .object({
+    start: z
+      .object({
+        initialValue: z.number(),
+        newValue: z.number(),
+      })
+      .strict()
+      .optional(),
+    current: z
+      .object({
+        initialValue: z.number(),
+        increasedPoints: z.number(),
+      })
+      .strict()
+      .optional(),
+    mod: z
+      .object({
+        initialValue: z.number(),
+        newValue: z.number(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
 interface Parameters {
   userId: string;
   characterId: string;
   attributeName: string;
-  initialAttributeValue: number;
-  increasedPoints: number;
+  body: z.infer<typeof bodySchema>;
 }
 
-// TODO Consider side effects of increasing attributes -> updated base values
-// TODO Update whole attribute not only current value. I.e. include start and mod
 // TODO rename function, etc. to update-attribute
-export async function increaseAttribute(request: Request): Promise<APIGatewayProxyResult> {
+export async function _updateAttribute(request: Request): Promise<APIGatewayProxyResult> {
   try {
     const params = validateRequest(request);
 
     console.log(`Update character ${params.characterId} of user ${params.userId}`);
-    console.log(
-      `Increase value of attribute '${params.attributeName}' from ${params.initialAttributeValue} to ${params.initialAttributeValue + params.increasedPoints}`,
-    );
+    console.log(`Update attribute '${params.attributeName}'`);
 
     const character = await getCharacterItem(params.userId, params.characterId);
-
     const characterSheet = character.characterSheet;
     const attributePointsOld = characterSheet.calculationPoints.attributePoints;
-    const attributePoints = structuredClone(attributePointsOld);
+    let attributePoints = structuredClone(attributePointsOld);
     const attributeOld = getAttribute(characterSheet.attributes, params.attributeName);
-    const attribute = structuredClone(attributeOld);
+    let attribute = structuredClone(attributeOld);
 
-    validatePassedAttributeValues(attribute, params);
-
-    console.log(`Attribute total cost before increasing: ${attribute.totalCost}`);
-    console.log(`Available attribute points before increasing: ${attributePoints.available}`);
-
-    if (params.initialAttributeValue + params.increasedPoints === attribute.current) {
-      console.log("Attribute value already increased to target value. Nothing to do.");
-      const response = {
-        statusCode: 200,
-        body: JSON.stringify({
-          characterId: params.characterId,
-          userId: params.userId,
-          attributeName: params.attributeName,
-          attribute: {
-            old: attributeOld,
-            new: attribute,
-          },
-          attributePoints: {
-            old: attributePointsOld,
-            new: attributePoints,
-          },
-        }),
-      };
-      console.log(response);
-
-      return response;
+    if (params.body.start) {
+      attribute = updateStartValue(attribute, params.body.start);
     }
 
-    const increaseCost = 1; // Increase cost are always 1 for attributes
-    for (let i = 0; i < params.increasedPoints; i++) {
-      console.debug("---------------------------");
+    if (params.body.current) {
+      const result = updateCurrentValue(attribute, params.body.current, attributePoints);
+      attribute = result.attribute;
+      attributePoints = result.attributePoints;
+    }
 
-      if (increaseCost > attributePoints.available) {
-        throw new HttpError(400, "Not enough attribute points to increase the attribute!", {
-          characterId: params.characterId,
-          attributeName: params.attributeName,
-        });
-      }
-
-      console.debug(`Attribute value: ${attribute.current}`);
-      console.debug(`Attribute total cost: ${attribute.totalCost}`);
-      console.debug(`Available attribute points: ${attributePoints.available}`);
-      console.debug(`Increasing attribute by 1 for ${increaseCost} attribute point...`);
-      attribute.current += 1;
-      attribute.totalCost += increaseCost;
-      attributePoints.available -= increaseCost;
+    if (params.body.mod) {
+      attribute = updateModValue(attribute, params.body.mod);
     }
 
     await updateAttribute(params.userId, params.characterId, params.attributeName, attribute, attributePoints);
+
+    // TODO Consider side effects of increasing attributes -> updated base values
 
     const response = {
       statusCode: 200,
@@ -122,63 +111,125 @@ export async function increaseAttribute(request: Request): Promise<APIGatewayPro
 }
 
 function validateRequest(request: Request): Parameters {
-  console.log("Validate request");
+  try {
+    console.log("Validate request");
 
-  const userId = decodeUserId(request.headers.authorization ?? request.headers.Authorization);
+    const userId = decodeUserId(request.headers.authorization ?? request.headers.Authorization);
 
-  /**
-   * This conversion is necessary if the Lambda is called via AWS Step Functions.
-   * The input data of a state machine is a string.
-   */
-  if (typeof request.body?.initialValue === "string") {
-    request.body.initialValue = Number(request.body.initialValue);
+    const characterId = request.pathParameters?.["character-id"];
+    const attributeName = request.pathParameters?.["attribute-name"];
+    if (typeof characterId !== "string" || typeof attributeName !== "string") {
+      throw new HttpError(400, "Invalid input values!");
+    }
+
+    validateUUID(characterId);
+
+    const body = bodySchema.parse(request.body);
+
+    if (body.current && body.current.increasedPoints <= 0) {
+      throw new HttpError(400, "Points to increase are negative or null! The value must be greater than or equal 1.", {
+        increasedPoints: body.current.increasedPoints,
+      });
+    }
+
+    return {
+      userId: userId,
+      characterId: characterId,
+      attributeName: attributeName,
+      body: body,
+    };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      console.error("Validation errors:", error.errors);
+      throw new HttpError(400, "Invalid input values!");
+    }
+
+    // Rethrow other errors
+    throw error;
   }
-  if (typeof request.body?.increasedPoints === "string") {
-    request.body.increasedPoints = Number(request.body.increasedPoints);
-  }
-
-  if (
-    typeof request.pathParameters?.["character-id"] !== "string" ||
-    typeof request.pathParameters?.["attribute-name"] !== "string" ||
-    typeof request.body?.initialValue !== "number" ||
-    typeof request.body?.increasedPoints !== "number"
-  ) {
-    throw new HttpError(400, "Invalid input values!");
-  }
-
-  const params: Parameters = {
-    userId: userId,
-    characterId: request.pathParameters["character-id"],
-    attributeName: request.pathParameters["attribute-name"],
-    initialAttributeValue: request.body.initialValue,
-    increasedPoints: request.body.increasedPoints,
-  };
-
-  if (params.increasedPoints <= 0) {
-    throw new HttpError(400, "Points to increase are negative! The value must be greater than or equal 1.", {
-      increasedPoints: params.increasedPoints,
-    });
-  }
-
-  validateUUID(params.characterId);
-
-  return params;
 }
 
-function validatePassedAttributeValues(attribute: Attribute, params: Parameters) {
-  console.log("Compare passed attribute values with the values in the backend");
+function updateStartValue(attribute: Attribute, startValue: any): Attribute {
+  console.log(`Update start value of the attribute from ${startValue.initialValue} to ${startValue.newValue}`);
 
-  if (
-    params.initialAttributeValue !== attribute.current &&
-    params.initialAttributeValue + params.increasedPoints !== attribute.current
-  ) {
+  if (startValue.initialValue !== attribute.start && startValue.newValue !== attribute.start) {
     throw new HttpError(409, "The passed attribute value doesn't match the value in the backend!", {
-      characterId: params.characterId,
-      attributeName: params.attributeName,
-      passedAttributeValue: params.initialAttributeValue,
-      backendAttributeValue: attribute.current,
+      passedStartValue: startValue.initialValue,
+      backendStartValue: attribute.start,
     });
   }
 
-  console.log("Passed attribute values match the values in the backend");
+  if (startValue.newValue === attribute.start) {
+    console.log("Attribute start value already updated to target value. Nothing to do.");
+    return attribute;
+  } else {
+    attribute.start = startValue.newValue;
+    return attribute;
+  }
+}
+
+function updateCurrentValue(
+  attribute: Attribute,
+  currentValue: any,
+  attributePoints: CalculationPoints,
+): { attribute: Attribute; attributePoints: CalculationPoints } {
+  console.log(
+    `Update current value of the attribute from ${currentValue.initialValue} to ${currentValue.initialValue + currentValue.increasedPoints}`,
+  );
+
+  if (
+    currentValue.initialValue !== attribute.current &&
+    currentValue.initialValue + currentValue.increasedPoints !== attribute.current
+  ) {
+    throw new HttpError(409, "The passed attribute value doesn't match the value in the backend!", {
+      passedCurrentValue: currentValue.initialValue,
+      backendCurrentValue: attribute.current,
+    });
+  }
+
+  if (currentValue.initialValue + currentValue.increasedPoints === attribute.current) {
+    console.log("Attribute current value already updated to target value. Nothing to do.");
+    return { attribute, attributePoints };
+  } else {
+    console.log(`Attribute total cost before increasing: ${attribute.totalCost}`);
+    console.log(`Available attribute points before increasing: ${attributePoints.available}`);
+
+    const increaseCost = 1; // Increase cost are always 1 for attributes
+    for (let i = 0; i < currentValue.increasedPoints; i++) {
+      console.debug("---------------------------");
+
+      if (increaseCost > attributePoints.available) {
+        throw new HttpError(400, "Not enough attribute points to increase the attribute!");
+      }
+
+      console.debug(`Attribute value: ${attribute.current}`);
+      console.debug(`Attribute total cost: ${attribute.totalCost}`);
+      console.debug(`Available attribute points: ${attributePoints.available}`);
+      console.debug(`Increasing attribute by 1 for ${increaseCost} attribute point...`);
+      attribute.current += 1;
+      attribute.totalCost += increaseCost;
+      attributePoints.available -= increaseCost;
+    }
+
+    return { attribute, attributePoints };
+  }
+}
+
+function updateModValue(attribute: Attribute, modValue: any): Attribute {
+  console.log(`Update mod value of the attribute from ${modValue.initialValue} to ${modValue.newValue}`);
+
+  if (modValue.initialValue !== attribute.mod && modValue.newValue !== attribute.mod) {
+    throw new HttpError(409, "The passed attribute value doesn't match the value in the backend!", {
+      passedModValue: modValue.initialValue,
+      backendModValue: attribute.mod,
+    });
+  }
+
+  if (modValue.newValue === attribute.mod) {
+    console.log("Attribute mod value already updated to target value. Nothing to do.");
+    return attribute;
+  } else {
+    attribute.mod = modValue.newValue;
+    return attribute;
+  }
 }

--- a/backend/src/lambdas/update-attribute/index.ts
+++ b/backend/src/lambdas/update-attribute/index.ts
@@ -54,7 +54,6 @@ interface Parameters {
   body: z.infer<typeof bodySchema>;
 }
 
-// TODO rename function, etc. to update-attribute
 export async function _updateAttribute(request: Request): Promise<APIGatewayProxyResult> {
   try {
     const params = validateRequest(request);

--- a/backend/src/lambdas/update-attribute/package-lock.json
+++ b/backend/src/lambdas/update-attribute/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "increase-attribute",
+  "name": "update-attribute",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "increase-attribute",
+      "name": "update-attribute",
       "version": "1.0.0",
       "devDependencies": {
         "@types/aws-lambda": "^8.10.145",
@@ -20,9 +20,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.18.tgz",
-      "integrity": "sha512-v1DKRfUdyW+jJhZNEI1PYy29S2YRxMV5AOO/x/SjKmW0acCIOqmbj6Haf9eHAhsPmrhlHSxEhv/1WszcLWV4cg==",
+      "version": "22.15.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.30.tgz",
+      "integrity": "sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/backend/src/lambdas/update-attribute/package.json
+++ b/backend/src/lambdas/update-attribute/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "increase-attribute",
+  "name": "update-attribute",
   "version": "1.0.0",
   "main": "index.mjs",
   "type": "module",

--- a/backend/src/lambdas/update-skill/index.ts
+++ b/backend/src/lambdas/update-skill/index.ts
@@ -184,7 +184,7 @@ function validateRequest(request: Request): Parameters {
         400,
         "Points to increase skill value are negative or null! The value must be greater than or equal 1.",
         {
-          increasedPoints: body.current?.increasedPoints,
+          increasedPoints: body.current.increasedPoints,
         },
       );
     }

--- a/backend/test/update-attribute/update-attribute.test.ts
+++ b/backend/test/update-attribute/update-attribute.test.ts
@@ -4,7 +4,7 @@ import { fakeHeaders, dummyHeaders, fakeUserId } from "../test-data/request.js";
 import { fakeCharacterResponse, mockDynamoDBGetCharacterResponse } from "../test-data/response.js";
 import { fakeCharacterId } from "../test-data/character.js";
 import { getAttribute } from "config/index.js";
-import { _updateAttribute } from "increase-attribute/index.js";
+import { _updateAttribute } from "update-attribute/index.js";
 import { expectHttpError } from "../utils.js";
 
 describe("Invalid requests", () => {
@@ -225,7 +225,7 @@ describe("Invalid requests", () => {
 describe("Valid requests", () => {
   const idempotentTestCases = [
     {
-      name: "Attribute has already been increased to the target start value (idempotency)",
+      name: "Attribute has already been updated to the target start value (idempotency)",
       request: {
         headers: fakeHeaders,
         pathParameters: {
@@ -261,7 +261,7 @@ describe("Valid requests", () => {
       expectedStatusCode: 200,
     },
     {
-      name: "Attribute has already been increased to the target mod value (idempotency)",
+      name: "Attribute has already been updated to the target mod value (idempotency)",
       request: {
         headers: fakeHeaders,
         pathParameters: {

--- a/terraform/api-gateway.tf
+++ b/terraform/api-gateway.tf
@@ -25,7 +25,7 @@ resource "aws_iam_role_policy" "api_gateway_policy" {
         Action = "states:StartSyncExecution",
         Resource = [
           aws_sfn_state_machine.update_skill_state_machine.arn,
-          aws_sfn_state_machine.increase_attribute_state_machine.arn
+          aws_sfn_state_machine.update_attribute_state_machine.arn
         ]
       }
     ]
@@ -133,7 +133,7 @@ module "attribute_name_patch" {
   }
   aws_region        = data.aws_region.current.name
   credentials       = aws_iam_role.api_gateway_role.arn
-  state_machine_arn = aws_sfn_state_machine.increase_attribute_state_machine.arn
+  state_machine_arn = aws_sfn_state_machine.update_attribute_state_machine.arn
 }
 
 // ================== OPTIONS /characters/{character-id}/attributes/{attribute-name} ==================

--- a/terraform/lambdas.tf
+++ b/terraform/lambdas.tf
@@ -98,9 +98,9 @@ module "get_skill_increase_cost_lambda" {
   api_gateway_arn = aws_api_gateway_rest_api.pnp_rest_api.execution_arn
 }
 
-module "increase_attribute_lambda" {
+module "update_attribute_lambda" {
   source        = "./modules/lambda_function"
-  function_name = "increase-attribute"
+  function_name = "update-attribute"
   environment_vars = {
     TABLE_NAME_CHARACTERS = local.characters_table_name
   }


### PR DESCRIPTION
- Rename increase-attribute to update-attribute -> all attribute values can be changed
- Update Lambda for attribute changes: All attribute values (start, current and mod value) can be updated now via the endpoint
- Update tests for update-attribute
- Add tests to check for concrete attribute total costs