### PR TITLE
fix: Make patch combat values endpoint idempotent again

### DIFF
--- a/backend/test/add-history-record/add-history-record.test.ts
+++ b/backend/test/add-history-record/add-history-record.test.ts
@@ -514,6 +514,8 @@ describe("Valid requests", () => {
     });
   });
 
+  const latestHistoryBlock = fakeHistoryBlockListResponse.Items[fakeHistoryBlockListResponse.Items.length - 1];
+
   const idempotencyTestCasesForExistingHistoryBlock = [
     {
       name: "Add a redundant history record to existing block (idempotency)",
@@ -523,50 +525,11 @@ describe("Valid requests", () => {
           "character-id": fakeCharacterId,
         },
         queryStringParameters: null,
-        body: {
-          userId: fakeUserId,
-          type: RecordType.SKILL_CHANGED,
-          name: "body/athletics",
-          data: {
-            old: {
-              skill: {
-                activated: true,
-                start: 12,
-                current: 16,
-                mod: 4,
-                totalCost: 40,
-                defaultCostCategory: CostCategory.CAT_2,
-              },
-            },
-            new: {
-              skill: {
-                activated: true,
-                start: 14,
-                current: 20,
-                mod: 5,
-                totalCost: 44,
-                defaultCostCategory: CostCategory.CAT_2,
-              },
-            },
-          },
-          learningMethod: "NORMAL",
-          calculationPoints: {
-            adventurePoints: {
-              old: {
-                start: 0,
-                available: 100,
-                total: 200,
-              },
-              new: {
-                start: 0,
-                available: 96,
-                total: 200,
-              },
-            },
-            attributePoints: null,
-          },
-          comment: null,
-        },
+        body: (() => {
+          const record = latestHistoryBlock.changes[latestHistoryBlock.changes.length - 1];
+          const { type, name, data, learningMethod, calculationPoints, comment } = record;
+          return { userId: fakeUserId, type, name, data, learningMethod, calculationPoints, comment };
+        })(),
       },
       expectedStatusCode: 200,
     },
@@ -584,7 +547,7 @@ describe("Valid requests", () => {
       const parsedBody = addHistoryRecordResponseSchema.parse(JSON.parse(result.body));
       expect(parsedBody.type).toBe(_case.request.body.type);
       expect(parsedBody.name).toBe(_case.request.body.name);
-      expect(parsedBody.number).toBe(fakeHistoryBlock2.changes[fakeHistoryBlock2.changes.length - 1].number);
+      expect(parsedBody.number).toBe(latestHistoryBlock.changes[latestHistoryBlock.changes.length - 1].number);
       expect(parsedBody.id).toBeDefined();
       expect(parsedBody.data.old).toEqual(_case.request.body.data.old);
       expect(parsedBody.data.new).toEqual(_case.request.body.data.new);

--- a/backend/test/add-special-ability/add-special-ability.test.ts
+++ b/backend/test/add-special-ability/add-special-ability.test.ts
@@ -134,7 +134,7 @@ describe("Valid requests", () => {
         },
         queryStringParameters: null,
         body: {
-          specialAbility: "Battle Cry",
+          specialAbility: fakeCharacter.characterSheet.specialAbilities[0],
         },
       },
       expectedStatusCode: 200,

--- a/backend/test/update-attribute/update-attribute.test.ts
+++ b/backend/test/update-attribute/update-attribute.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { fakeHeaders, dummyHeaders, fakeUserId } from "../test-data/request.js";
 import { fakeCharacterResponse, mockDynamoDBGetCharacterResponse } from "../test-data/response.js";
-import { fakeCharacterId } from "../test-data/character.js";
+import { fakeCharacter, fakeCharacterId } from "../test-data/character.js";
 import { CharacterSheet, updateAttributeResponseSchema } from "api-spec";
 import { getAttribute } from "core";
 import { _updateAttribute } from "update-attribute";
@@ -254,8 +254,8 @@ describe("Valid requests", () => {
         queryStringParameters: null,
         body: {
           start: {
-            initialValue: 15,
-            newValue: 17,
+            initialValue: fakeCharacter.characterSheet.attributes.endurance.start - 2,
+            newValue: fakeCharacter.characterSheet.attributes.endurance.start,
           },
         },
       },
@@ -272,7 +272,7 @@ describe("Valid requests", () => {
         queryStringParameters: null,
         body: {
           current: {
-            initialValue: 17,
+            initialValue: fakeCharacter.characterSheet.attributes.endurance.current - 1,
             increasedPoints: 1,
           },
         },
@@ -290,8 +290,8 @@ describe("Valid requests", () => {
         queryStringParameters: null,
         body: {
           mod: {
-            initialValue: 0,
-            newValue: 1,
+            initialValue: fakeCharacter.characterSheet.attributes.endurance.mod - 1,
+            newValue: fakeCharacter.characterSheet.attributes.endurance.mod,
           },
         },
       },

--- a/backend/test/update-base-value/update-base-value.test.ts
+++ b/backend/test/update-base-value/update-base-value.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { fakeHeaders, dummyHeaders, fakeUserId } from "../test-data/request.js";
 import { fakeCharacterResponse, mockDynamoDBGetCharacterResponse } from "../test-data/response.js";
-import { fakeCharacterId } from "../test-data/character.js";
+import { fakeCharacter, fakeCharacterId } from "../test-data/character.js";
 import { updateBaseValueResponseSchema } from "api-spec";
 import { getBaseValue } from "core";
 import { _updateBaseValue } from "update-base-value";
@@ -272,8 +272,8 @@ describe("Valid requests", () => {
         queryStringParameters: null,
         body: {
           start: {
-            initialValue: 30,
-            newValue: 40,
+            initialValue: fakeCharacter.characterSheet.baseValues.healthPoints.start - 10,
+            newValue: fakeCharacter.characterSheet.baseValues.healthPoints.start,
           },
         },
       },
@@ -290,8 +290,8 @@ describe("Valid requests", () => {
         queryStringParameters: null,
         body: {
           byLvlUp: {
-            initialValue: 20,
-            newValue: 23,
+            initialValue: fakeCharacter.characterSheet.baseValues.healthPoints.byLvlUp! - 3,
+            newValue: fakeCharacter.characterSheet.baseValues.healthPoints.byLvlUp,
           },
         },
       },
@@ -308,8 +308,8 @@ describe("Valid requests", () => {
         queryStringParameters: null,
         body: {
           mod: {
-            initialValue: 3,
-            newValue: 10,
+            initialValue: fakeCharacter.characterSheet.baseValues.healthPoints.mod - 7,
+            newValue: fakeCharacter.characterSheet.baseValues.healthPoints.mod,
           },
         },
       },

--- a/backend/test/update-calculation-points/update-calculation-points.test.ts
+++ b/backend/test/update-calculation-points/update-calculation-points.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { fakeHeaders, dummyHeaders, fakeUserId } from "../test-data/request.js";
 import { fakeCharacterResponse, mockDynamoDBGetCharacterResponse } from "../test-data/response.js";
-import { fakeCharacterId } from "../test-data/character.js";
+import { fakeCharacter, fakeCharacterId } from "../test-data/character.js";
 import { updateCalculationPointsResponseSchema } from "api-spec";
 import { _updateCalculationPoints } from "update-calculation-points";
 import { expectHttpError } from "../utils.js";
@@ -227,8 +227,8 @@ describe("Valid requests", () => {
         body: {
           adventurePoints: {
             start: {
-              initialValue: 80,
-              newValue: 100,
+              initialValue: fakeCharacter.characterSheet.calculationPoints.adventurePoints.start - 20,
+              newValue: fakeCharacter.characterSheet.calculationPoints.adventurePoints.start,
             },
           },
         },
@@ -246,8 +246,8 @@ describe("Valid requests", () => {
         body: {
           attributePoints: {
             start: {
-              initialValue: 5,
-              newValue: 10,
+              initialValue: fakeCharacter.characterSheet.calculationPoints.attributePoints.start - 5,
+              newValue: fakeCharacter.characterSheet.calculationPoints.attributePoints.start,
             },
           },
         },
@@ -265,7 +265,7 @@ describe("Valid requests", () => {
         body: {
           adventurePoints: {
             total: {
-              initialValue: 200,
+              initialValue: fakeCharacter.characterSheet.calculationPoints.adventurePoints.total - 100,
               increasedPoints: 100,
             },
           },
@@ -284,7 +284,7 @@ describe("Valid requests", () => {
         body: {
           attributePoints: {
             total: {
-              initialValue: 30,
+              initialValue: fakeCharacter.characterSheet.calculationPoints.attributePoints.total - 20,
               increasedPoints: 20,
             },
           },

--- a/backend/test/update-combat-values/update-combat-values.test.ts
+++ b/backend/test/update-combat-values/update-combat-values.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { fakeHeaders, dummyHeaders, fakeUserId } from "../test-data/request.js";
 import { fakeCharacterResponse, mockDynamoDBGetCharacterResponse } from "../test-data/response.js";
-import { fakeCharacterId } from "../test-data/character.js";
+import { fakeCharacter, fakeCharacterId } from "../test-data/character.js";
 import { getCombatSkillHandling, getCombatValues } from "core";
 import { Character, CombatSkillName, SkillName, updateCombatValuesResponseSchema } from "api-spec";
 import { expectHttpError } from "../utils.js";
@@ -235,7 +235,7 @@ describe("Invalid requests", () => {
 describe("Valid requests", () => {
   const validTestCases = [
     {
-      name: "Combat values already updated to target value (idempotency)",
+      name: "Melee combat values already updated to target value (idempotency)",
       request: {
         headers: fakeHeaders,
         pathParameters: {
@@ -246,12 +246,35 @@ describe("Valid requests", () => {
         queryStringParameters: null,
         body: {
           skilledAttackValue: {
-            initialValue: 10,
+            initialValue: fakeCharacter.characterSheet.combatValues.melee.thrustingWeapons1h.skilledAttackValue - 3,
             increasedPoints: 3,
           },
           skilledParadeValue: {
-            initialValue: 8,
+            initialValue: fakeCharacter.characterSheet.combatValues.melee.thrustingWeapons1h.skilledParadeValue - 2,
             increasedPoints: 2,
+          },
+        },
+      },
+      expectedStatusCode: 200,
+    },
+    {
+      name: "Ranged combat values already updated to target value (idempotency)",
+      request: {
+        headers: fakeHeaders,
+        pathParameters: {
+          "character-id": fakeCharacterId,
+          "combat-category": "ranged",
+          "combat-skill-name": "firearmSimple",
+        },
+        queryStringParameters: null,
+        body: {
+          skilledAttackValue: {
+            initialValue: fakeCharacter.characterSheet.combatValues.ranged.firearmSimple.skilledAttackValue - 3,
+            increasedPoints: 3,
+          },
+          skilledParadeValue: {
+            initialValue: fakeCharacter.characterSheet.combatValues.ranged.firearmSimple.skilledParadeValue,
+            increasedPoints: 0,
           },
         },
       },

--- a/backend/test/update-combat-values/update-combat-values.test.ts
+++ b/backend/test/update-combat-values/update-combat-values.test.ts
@@ -308,11 +308,9 @@ describe("Valid requests", () => {
       expect(parsedBody.combatValues.old).toStrictEqual(oldSkillCombatValues);
       expect(parsedBody.combatValues.new).toStrictEqual(parsedBody.combatValues.old);
 
-      expect(parsedBody.combatValues.new.attackValue).toBe(oldSkillCombatValues.attackValue);
       expect(parsedBody.combatValues.new.skilledAttackValue).toBe(
         _case.request.body.skilledAttackValue.initialValue + _case.request.body.skilledAttackValue.increasedPoints,
       );
-      expect(parsedBody.combatValues.new.paradeValue).toBe(oldSkillCombatValues.paradeValue);
       expect(parsedBody.combatValues.new.skilledParadeValue).toBe(
         _case.request.body.skilledParadeValue.initialValue + _case.request.body.skilledParadeValue.increasedPoints,
       );

--- a/backend/test/update-level/update-level.test.ts
+++ b/backend/test/update-level/update-level.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { fakeHeaders, dummyHeaders, fakeUserId } from "../test-data/request.js";
 import { fakeCharacterResponse, mockDynamoDBGetCharacterResponse } from "../test-data/response.js";
-import { fakeCharacterId } from "../test-data/character.js";
+import { fakeCharacter, fakeCharacterId } from "../test-data/character.js";
 import { updateLevelResponseSchema } from "api-spec";
 import { _updateLevel } from "update-level";
 import { expectHttpError } from "../utils.js";
@@ -133,7 +133,7 @@ describe("Valid requests", () => {
         },
         queryStringParameters: null,
         body: {
-          initialLevel: 4,
+          initialLevel: fakeCharacter.characterSheet.generalInformation.level - 1,
         },
       },
       expectedStatusCode: 200,

--- a/backend/test/update-skill/update-skill.test.ts
+++ b/backend/test/update-skill/update-skill.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { fakeHeaders, dummyHeaders, fakeUserId } from "../test-data/request.js";
 import { fakeCharacterResponse, mockDynamoDBGetCharacterResponse } from "../test-data/response.js";
-import { fakeCharacterId } from "../test-data/character.js";
+import { fakeCharacter, fakeCharacterId } from "../test-data/character.js";
 import { getCombatCategory, getCombatValues, getSkill, combatValuesChanged, isCombatSkill } from "core";
 import { Character, SkillName, updateSkillResponseSchema } from "api-spec";
 import { _updateSkill } from "update-skill";
@@ -366,7 +366,7 @@ describe("Valid requests", () => {
         },
         queryStringParameters: null,
         body: {
-          activated: true,
+          activated: fakeCharacter.characterSheet.skills.body.athletics.activated,
           learningMethod: "NORMAL",
         },
       },
@@ -384,8 +384,8 @@ describe("Valid requests", () => {
         queryStringParameters: null,
         body: {
           start: {
-            initialValue: 9,
-            newValue: 12,
+            initialValue: fakeCharacter.characterSheet.skills.body.athletics.start - 3,
+            newValue: fakeCharacter.characterSheet.skills.body.athletics.start,
           },
         },
       },
@@ -403,7 +403,7 @@ describe("Valid requests", () => {
         queryStringParameters: null,
         body: {
           current: {
-            initialValue: 12,
+            initialValue: fakeCharacter.characterSheet.skills.body.athletics.current - 4,
             increasedPoints: 4,
           },
           learningMethod: "NORMAL",
@@ -423,8 +423,8 @@ describe("Valid requests", () => {
         queryStringParameters: null,
         body: {
           mod: {
-            initialValue: 2,
-            newValue: 4,
+            initialValue: fakeCharacter.characterSheet.skills.body.athletics.mod - 2,
+            newValue: fakeCharacter.characterSheet.skills.body.athletics.mod,
           },
         },
       },


### PR DESCRIPTION
- fix: patch combat values endpoint does not update the combat values anymore for multiple calls with the same payload (idempotent behavior)
- fix: Split tests for update combat values into idempotency and update test cases. The error of non idempotent behavior for the patch combat values endpoint was not detected because a) the test data values were hardcoded and b) the test assertions were not correct for the idempotency tests
- Update tests for idempotency: Reference values from test data and avoid hardcoded values. This should avoid undetected errors as for the 'update combat values' case.