### PR TITLE
Serialize AWS environment operations in CircleCI

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -57,16 +57,25 @@ All workflows derive `TF_WORKSPACE` from the environment parameter and set it au
 
 ## Pipeline Workflows
 
+### Serialized AWS Environment Operations
+
+The dev and prod AWS environment operations are serialized with CircleCI job groups and per-environment serial group keys:
+
+- `<< pipeline.project.slug >>/aws-dev`: dev deployment, manual dev component tests, and manual dev destroy
+- `<< pipeline.project.slug >>/aws-prod`: prod deployment, automatic/manual prod component tests, and manual prod destroy
+
+Only the environment-touching job groups acquire these locks. Formatting, linting, builds, and unit tests can still run concurrently before a deployment waits for the matching environment lock.
+
 ### `build-deploy-dev`
 
 - Runs on every commit except the special `deploy-shared`, `component-tests` and `delete-services` pipelines
-- Deploys the dev environment
+- Deploys the dev environment under the dev AWS environment serial group
 
 ### `build-deploy-prod`
 
 - Runs on every commit to `main` except the special `deploy-shared`, `component-tests` and `delete-services` pipelines
-- Deploys the prod environment
-- Runs backend component tests after the backend and infrastructure deploy finishes
+- Deploys the prod environment under the prod AWS environment serial group
+- Runs backend component tests under the same prod AWS environment serial group after the backend and infrastructure deploy finishes
 
 ### Deploy Shared Infrastructure
 
@@ -78,9 +87,9 @@ All workflows derive `TF_WORKSPACE` from the environment parameter and set it au
 ### Component Tests
 
 - Triggers when `run-component-tests=true`
-- Runs backend component tests against the environment specified by the `env` parameter (defaults to `dev`)
+- Runs backend component tests against the environment specified by the `env` parameter (defaults to `dev`) under the matching AWS environment serial group
 
 ### Delete Services
 
 - Triggers when `delete-services=true`
-- Destroys the Terraform resources for the environment specified by the `env` parameter (defaults to `dev`)
+- Destroys the Terraform resources for the environment specified by the `env` parameter (defaults to `dev`) under the matching AWS environment serial group

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,58 @@ executors:
       - image: cimg/node:24.14
     resource_class: small
 
+job-groups:
+  deploy-application-dev:
+    jobs:
+      - deploy-backend-and-app-infrastructure:
+          name: deploy-backend-and-app-infrastructure-dev
+          env: dev
+      - build-frontend:
+          name: build-frontend-dev
+          env: dev
+          requires:
+            - deploy-backend-and-app-infrastructure-dev
+      - deploy-frontend:
+          name: deploy-frontend-dev
+          env: dev
+          requires:
+            - build-frontend-dev
+            - deploy-backend-and-app-infrastructure-dev
+
+  deploy-application-prod:
+    jobs:
+      - deploy-backend-and-app-infrastructure:
+          name: deploy-backend-and-app-infrastructure-prod
+          env: prod
+      - run-backend-component-tests:
+          name: run-backend-component-tests-prod
+          env: prod
+          requires:
+            - deploy-backend-and-app-infrastructure-prod
+      - build-frontend:
+          name: build-frontend-prod
+          env: prod
+          requires:
+            - deploy-backend-and-app-infrastructure-prod
+      - deploy-frontend:
+          name: deploy-frontend-prod
+          env: prod
+          requires:
+            - build-frontend-prod
+            - deploy-backend-and-app-infrastructure-prod
+
+  run-environment-component-tests:
+    jobs:
+      - run-backend-component-tests:
+          name: run-backend-component-tests-<< pipeline.parameters.env >>
+          env: << pipeline.parameters.env >>
+
+  destroy-environment:
+    jobs:
+      - terraform-destroy:
+          name: terraform-destroy-<< pipeline.parameters.env >>
+          env: << pipeline.parameters.env >>
+
 workflows:
   build-deploy-dev:
     when:
@@ -49,29 +101,15 @@ workflows:
       - run-backend-unit-tests
       - run-frontend-tests
       - lint-terraform-code
-      - deploy-backend-and-app-infrastructure:
-          name: deploy-backend-and-app-infrastructure-dev
-          env: dev
+      - deploy-application-dev:
+          serial-group: << pipeline.project.slug >>/aws-dev
           requires:
             - check-format-files
             - lint-typescript-code
             - build-backend
             - run-backend-unit-tests
-            - lint-terraform-code
-      - build-frontend:
-          name: build-frontend-dev
-          env: dev
-          requires:
-            - deploy-backend-and-app-infrastructure-dev
-      - deploy-frontend:
-          name: deploy-frontend-dev
-          env: dev
-          requires:
-            - check-format-files
-            - lint-typescript-code
-            - build-frontend-dev
             - run-frontend-tests
-            - deploy-backend-and-app-infrastructure-dev
+            - lint-terraform-code
 
   build-deploy-prod:
     when:
@@ -87,34 +125,15 @@ workflows:
       - run-backend-unit-tests
       - run-frontend-tests
       - lint-terraform-code
-      - deploy-backend-and-app-infrastructure:
-          name: deploy-backend-and-app-infrastructure-prod
-          env: prod
+      - deploy-application-prod:
+          serial-group: << pipeline.project.slug >>/aws-prod
           requires:
             - check-format-files
             - lint-typescript-code
             - build-backend
             - run-backend-unit-tests
-            - lint-terraform-code
-      - run-backend-component-tests:
-          name: run-backend-component-tests-prod
-          env: prod
-          requires:
-            - deploy-backend-and-app-infrastructure-prod
-      - build-frontend:
-          name: build-frontend-prod
-          env: prod
-          requires:
-            - deploy-backend-and-app-infrastructure-prod
-      - deploy-frontend:
-          name: deploy-frontend-prod
-          env: prod
-          requires:
-            - check-format-files
-            - lint-typescript-code
-            - build-frontend-prod
             - run-frontend-tests
-            - deploy-backend-and-app-infrastructure-prod
+            - lint-terraform-code
 
   deploy-shared:
     when: << pipeline.parameters.deploy-shared >>
@@ -132,16 +151,14 @@ workflows:
         - not: << pipeline.parameters.delete-services >>
         - << pipeline.parameters.run-component-tests >>
     jobs:
-      - run-backend-component-tests:
-          name: run-backend-component-tests-<< pipeline.parameters.env >>
-          env: << pipeline.parameters.env >>
+      - run-environment-component-tests:
+          serial-group: << pipeline.project.slug >>/aws-<< pipeline.parameters.env >>
 
   delete-services:
     when: << pipeline.parameters.delete-services >>
     jobs:
-      - terraform-destroy:
-          name: terraform-destroy-<< pipeline.parameters.env >>
-          env: << pipeline.parameters.env >>
+      - destroy-environment:
+          serial-group: << pipeline.project.slug >>/aws-<< pipeline.parameters.env >>
 
 jobs:
   check-format-files:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,17 +75,29 @@ job-groups:
             - build-frontend-prod
             - deploy-backend-and-app-infrastructure-prod
 
-  run-environment-component-tests:
+  run-environment-component-tests-dev:
     jobs:
       - run-backend-component-tests:
-          name: run-backend-component-tests-<< pipeline.parameters.env >>
-          env: << pipeline.parameters.env >>
+          name: run-backend-component-tests-dev
+          env: dev
 
-  destroy-environment:
+  run-environment-component-tests-prod:
+    jobs:
+      - run-backend-component-tests:
+          name: run-backend-component-tests-prod
+          env: prod
+
+  destroy-environment-dev:
     jobs:
       - terraform-destroy:
-          name: terraform-destroy-<< pipeline.parameters.env >>
-          env: << pipeline.parameters.env >>
+          name: terraform-destroy-dev
+          env: dev
+
+  destroy-environment-prod:
+    jobs:
+      - terraform-destroy:
+          name: terraform-destroy-prod
+          env: prod
 
 workflows:
   build-deploy-dev:
@@ -145,20 +157,43 @@ workflows:
             - check-format-files
             - lint-terraform-code
 
-  component-tests:
+  component-tests-dev:
     when:
       and:
         - not: << pipeline.parameters.delete-services >>
         - << pipeline.parameters.run-component-tests >>
+        - equal: [dev, << pipeline.parameters.env >>]
     jobs:
-      - run-environment-component-tests:
-          serial-group: << pipeline.project.slug >>/aws-<< pipeline.parameters.env >>
+      - run-environment-component-tests-dev:
+          serial-group: << pipeline.project.slug >>/aws-dev
 
-  delete-services:
-    when: << pipeline.parameters.delete-services >>
+  component-tests-prod:
+    when:
+      and:
+        - not: << pipeline.parameters.delete-services >>
+        - << pipeline.parameters.run-component-tests >>
+        - equal: [prod, << pipeline.parameters.env >>]
     jobs:
-      - destroy-environment:
-          serial-group: << pipeline.project.slug >>/aws-<< pipeline.parameters.env >>
+      - run-environment-component-tests-prod:
+          serial-group: << pipeline.project.slug >>/aws-prod
+
+  delete-services-dev:
+    when:
+      and:
+        - << pipeline.parameters.delete-services >>
+        - equal: [dev, << pipeline.parameters.env >>]
+    jobs:
+      - destroy-environment-dev:
+          serial-group: << pipeline.project.slug >>/aws-dev
+
+  delete-services-prod:
+    when:
+      and:
+        - << pipeline.parameters.delete-services >>
+        - equal: [prod, << pipeline.parameters.env >>]
+    jobs:
+      - destroy-environment-prod:
+          serial-group: << pipeline.project.slug >>/aws-prod
 
 jobs:
   check-format-files:


### PR DESCRIPTION
## Summary

- Add CircleCI job groups for dev/prod AWS application deployment flows.
- Apply per-environment `serial-group` keys so deployments, manual component tests, and environment destroy jobs queue instead of overlapping in the same AWS environment.
- Document the serialized dev/prod AWS environment operations in the CircleCI README.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".circleci/config.yml")'`
- `npm run format`
- `npm run lint`
- `npm run lint:terraform`
- `PATH=/usr/local/bin:/opt/homebrew/bin:$PATH npm run build`
- `PATH=/usr/local/bin:/opt/homebrew/bin:$PATH npm run test:unit --workspace backend`

## Notes

- `circleci` CLI is not installed in the local environment, so CircleCI-specific compilation should be confirmed by CI.
- The repository root does not define `npm run test:unit`; backend unit tests were run via the backend workspace script.
