### PR TITLE
Build(deps): Group Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      npm-version-updates:
+        applies-to: "version-updates"
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Group normal npm Dependabot version-update PRs into a single `npm-version-updates` group.
- Leave security updates outside the explicit version-update group.

## Validation
- `npm run format`
- `npm run lint`
- `npm run lint:terraform`
- `PATH=/usr/local/bin:/opt/homebrew/bin:$PATH npm run build`
- `PATH=/usr/local/bin:/opt/homebrew/bin:$PATH npm run test:unit --workspaces --if-present`
