### PR TITLE
Upgrade react-router to v8 to fix CSRF advisory

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-icons": "^5.7.0",
-    "react-router-dom": "^7.18.1",
+    "react-router": "^8.3.0",
     "zod": "^4.4.3",
     "zustand": "^5.0.14"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route, Navigate } from "react-router-dom";
+import { Routes, Route, Navigate } from "react-router";
 import { useEffect } from "react";
 import { useAuth } from "@/auth/AuthProvider";
 import { setTokenGetter } from "@/api/client";

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from "react-router-dom";
+import { Outlet } from "react-router";
 import { Sidebar } from "./Sidebar";
 import { useTheme } from "@/hooks/useTheme";
 

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { NavLink, useParams, useNavigate, useLocation } from "react-router-dom";
+import { NavLink, useParams, useNavigate, useLocation } from "react-router";
 import { clsx } from "clsx";
 import {
   LayoutDashboard,

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AuthProvider } from "@/auth/AuthProvider";
 import { ThemeProvider } from "@/hooks/useTheme";

--- a/frontend/src/pages/CharacterCreatePage.tsx
+++ b/frontend/src/pages/CharacterCreatePage.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useMemo } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { clsx } from "clsx";
 import { Check } from "lucide-react";

--- a/frontend/src/pages/CharacterSheetPage.tsx
+++ b/frontend/src/pages/CharacterSheetPage.tsx
@@ -1,4 +1,4 @@
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { Plus } from "lucide-react";

--- a/frontend/src/pages/CombatPage.tsx
+++ b/frontend/src/pages/CombatPage.tsx
@@ -1,4 +1,4 @@
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { clsx } from "clsx";

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Plus, Trash2, Copy, ChevronRight } from "lucide-react";
 import { t } from "@/i18n";

--- a/frontend/src/pages/HistoryPage.tsx
+++ b/frontend/src/pages/HistoryPage.tsx
@@ -1,4 +1,4 @@
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState, useCallback, useEffect, useRef } from "react";
 import { format } from "date-fns";

--- a/frontend/src/pages/LevelUpPage.tsx
+++ b/frontend/src/pages/LevelUpPage.tsx
@@ -1,4 +1,4 @@
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { clsx } from "clsx";

--- a/frontend/src/pages/SignInPage.tsx
+++ b/frontend/src/pages/SignInPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useAuth } from "@/auth/AuthProvider";
 import { isValidPassword } from "@/auth/passwordPolicy";
 import { t } from "@/i18n";

--- a/frontend/src/pages/SkillsPage.tsx
+++ b/frontend/src/pages/SkillsPage.tsx
@@ -1,4 +1,4 @@
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState, useMemo } from "react";
 import { clsx } from "clsx";

--- a/frontend/test/component-tests/pages/DashboardPage.test.tsx
+++ b/frontend/test/component-tests/pages/DashboardPage.test.tsx
@@ -6,8 +6,8 @@ import { createWrapper } from "../../helpers";
 
 // Mock navigate
 const mockNavigate = vi.fn();
-vi.mock("react-router-dom", async () => {
-  const actual = await vi.importActual("react-router-dom");
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
   return {
     ...actual,
     useNavigate: () => mockNavigate,

--- a/frontend/test/component-tests/pages/SignInPage.test.tsx
+++ b/frontend/test/component-tests/pages/SignInPage.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { ToastProvider } from "@/components/ui/Toast";
 import { SignInPage } from "@/pages/SignInPage";
 
@@ -21,8 +21,8 @@ vi.mock("@/auth/AuthProvider", () => ({
   }),
 }));
 
-vi.mock("react-router-dom", async () => {
-  const actual = await vi.importActual("react-router-dom");
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
   return {
     ...actual,
     useNavigate: () => mockNavigate,

--- a/frontend/test/helpers.tsx
+++ b/frontend/test/helpers.tsx
@@ -1,5 +1,5 @@
 import { render, type RenderOptions } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ToastProvider } from "@/components/ui/Toast";
 import { AuthProvider } from "@/auth/AuthProvider";

--- a/frontend/test/unit-tests/pages/CharacterSheetPage.test.tsx
+++ b/frontend/test/unit-tests/pages/CharacterSheetPage.test.tsx
@@ -35,8 +35,7 @@ vi.mock("@/api/character-edit", () => ({
   addSpecialAbility: vi.fn(),
 }));
 
-// Mock react-router-dom
-vi.mock("react-router-dom", () => ({
+vi.mock("react-router", () => ({
   useParams: () => ({ characterId: "test-character-id" }),
   useNavigate: () => vi.fn(),
 }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -389,7 +389,7 @@
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "react-icons": "^5.7.0",
-        "react-router-dom": "^7.18.1",
+        "react-router": "^8.3.0",
         "zod": "^4.4.3",
         "zustand": "^5.0.14"
       },
@@ -411,6 +411,27 @@
         "typescript-eslint": "^8.65.0",
         "vite": "^8.1.5",
         "vitest": "^4.1.9"
+      }
+    },
+    "frontend/node_modules/react-router": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie-es": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=22.22.0"
+      },
+      "peerDependencies": {
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "frontend/node_modules/typescript": {
@@ -2077,9 +2098,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2097,9 +2115,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2117,9 +2132,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2137,9 +2149,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2157,9 +2166,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2177,9 +2183,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2298,9 +2301,6 @@
       "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2590,9 +2590,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2610,9 +2607,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2630,9 +2624,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2650,9 +2641,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4222,18 +4210,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/core": {
       "resolved": "backend/src/core",
@@ -6247,44 +6228,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
     "node_modules/real-require": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
@@ -6429,12 +6372,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/set-history-comment": {
       "resolved": "backend/src/lambdas/set-history-comment",


### PR DESCRIPTION
Resolves Dependabot alert [#86](https://github.com/der-jd/pnp-character-application/security/dependabot/86) (high): *React Router: RSC Mode CSRF Bypass Allows Action Execution Before 400 Response*, affecting `react-router >= 7.12.0, < 8.3.0`.

## Why the upgrade is a major bump

`react-router-dom` is discontinued at `7.18.1` and pins `react-router` to that exact version, so the patched `8.3.0` is not reachable through it. React Router v8 removes the `react-router-dom` package entirely, so the fix means depending on `react-router` directly and moving every import.

## Changes

- `frontend`: replace `react-router-dom@^7.18.1` with `react-router@^8.3.0`
- Rewrite all `react-router-dom` imports to `react-router` across app code and tests

Every routing API the app uses — `BrowserRouter`, `MemoryRouter`, `Routes`, `Route`, `Navigate`, `Outlet`, `NavLink`, `useParams`, `useNavigate`, `useLocation` — is unchanged in v8, so this is an import rewrite with no call-site changes.

## Exposure

The app uses declarative mode with a plain `BrowserRouter` and has no RSC entry point, so it is not exposed to the advisory in practice.

## v8 requirements

| Requirement | Repo | |
|---|---|---|
| React >= 19.2.7 | 19.2.8 | ✅ |
| Vite >= 7 | 8.1.5 | ✅ |
| ESM-only | frontend is `"type": "module"` | ✅ |
| Node >= 22.22.0 | local dev is 22.18.0 | ⚠️ npm `EBADENGINE` warning only |

The Node floor surfaces as an npm warning, not an install or build failure — build, lint and tests all pass on 22.18.0. Worth bumping local/dev Node to 22.22.0+ to clear it.

## Verification

- `npm run build` (frontend) — passes
- `npm run lint` (all workspaces) + `tflint` — clean
- `npm test` (frontend) — 110 tests pass (96 unit, 14 component)
- `prettier --check` — clean

## Out of scope

`npm audit` still reports one high finding for `brace-expansion` (GHSA-mh99-v99m-4gvg), a transitive dev dependency with no Dependabot alert open against it. Left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
