### PR TITLE
Build(deps-dev): Bump brace-expansion from 5.0.7 to 5.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4094,16 +4094,16 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer-equal-constant-time": {


### PR DESCRIPTION
Fixes [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) (high, CVSS 7.5): *brace-expansion: DoS via unbounded expansion length causing an out-of-memory process crash*, affecting `brace-expansion <= 5.0.7`.

## Changes

Lockfile-only: `brace-expansion` 5.0.7 → 5.0.8.

The sole dependent is `minimatch`, which accepts `^5.0.5`, so the patched version fits the existing range and needs no `overrides` entry.

## Impact

`brace-expansion` is a dev-only transitive dependency of the ESLint toolchain (`eslint`, `@eslint/config-array`, `@typescript-eslint/typescript-estree` → `minimatch`). It never reaches runtime code, so exposure was limited to local and CI lint runs on untrusted glob patterns.

5.0.8 raises its own `engines` floor from `18 || 20 || >=22` to `20 || >=22`. No effect here — the repo already runs Node 22.

## Verification

- `npm audit` — 0 vulnerabilities (was 1 high)
- `npm run lint` (all workspaces) + `tflint` — clean, exercises the upgraded dependency
- `npm test` (frontend) — 110 pass; backend unit — 333 pass
- `prettier --check` — clean

Backend component tests were not run: they execute against the cloud environment and need `COMPONENT_TESTS_API_BASE_URL`, which is unavailable locally. They are unaffected by a dev-only lint dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
